### PR TITLE
[ansible] use ansible replace role instead of sed

### DIFF
--- a/ansible/roles/bootnode-collect-ip/tasks/main.yml
+++ b/ansible/roles/bootnode-collect-ip/tasks/main.yml
@@ -5,9 +5,8 @@
 
 - name: replace bootnode loopback ip with public ip
   delegate_to: localhost
-  shell: |
-    sed -i -e s/127.0.0.1/{{ bootnode_ip.ansible_facts.ipify_public_ip }}/g {{gantree_control_working}}/spec/chainSpecRaw.raw
-  args:
-    executable: /bin/bash
+  replace:
+    path: '{{gantree_control_working}}/spec/chainSpecRaw.raw'
+    regexp: '127.0.0.1'
+    replace: '{{ bootnode_ip.ansible_facts.ipify_public_ip }}'
   when: (not is_docker is defined) or (not is_docker == true)
-


### PR DESCRIPTION
This prevents non-exiting stderr from a warning about sed